### PR TITLE
Fix. User Admin List and Edit (Seeker/User) Pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
             <version>3.0.4.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-java8time</artifactId>
+            <version>3.0.4.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.javafaker</groupId>
             <artifactId>javafaker</artifactId>
             <version>0.17.2</version>

--- a/src/main/java/com/jm/jobseekerplatform/controller/AdminController.java
+++ b/src/main/java/com/jm/jobseekerplatform/controller/AdminController.java
@@ -104,7 +104,9 @@ public class AdminController {
         model.addAttribute("employerUser", employerUser);
         model.addAttribute("employerProfile", employerUser.getProfile());
         model.addAttribute("vacancies", vacancyService.getAllByEmployerProfileId(employerUser.getProfile().getId()));
-        model.addAttribute("photoimg", Base64.getEncoder().encodeToString(employerUser.getProfile().getLogo()));
+        if(employerUser.getProfile().getLogo() != null) {
+            model.addAttribute("photoimg", Base64.getEncoder().encodeToString(employerUser.getProfile().getLogo()));
+        }
 
         return "admin/admin_employer_edit";
     }
@@ -144,7 +146,10 @@ public class AdminController {
 
         model.addAttribute("seekerUser", seekerUser);
         model.addAttribute("seekerProfile", seekerUser.getProfile());
-        model.addAttribute("photoimg", Base64.getEncoder().encodeToString(seekerUser.getProfile().getLogo()));
+        if(seekerUser.getProfile().getLogo() != null){
+            model.addAttribute("photoimg", Base64.getEncoder().encodeToString(seekerUser.getProfile().getLogo()));
+        }
+
 
         return "admin/admin_seeker_edit";
     }

--- a/src/main/resources/static/js/admin/admin_employers.js
+++ b/src/main/resources/static/js/admin/admin_employers.js
@@ -76,7 +76,8 @@ $('#editEmployerForm').click(function (event) {
         'authority': userAuthority,
         'enabled': enabled,
         'confirm': confirm,
-        'profile': profile
+        'profile': profile,
+        'type': 'employer'
     };
 
     $.ajax({

--- a/src/main/resources/static/js/admin/admin_seekers.js
+++ b/src/main/resources/static/js/admin/admin_seekers.js
@@ -78,7 +78,8 @@ $('#editSeekerForm').click(function (event) {
         'authority': userAuthority,
         'enabled': enabled,
         'confirm': confirm,
-        'profile': profile
+        'profile': profile,
+        'type': 'seeker'
     };
 
     $.ajax({

--- a/src/main/resources/templates/admin/admin_employer_edit.html
+++ b/src/main/resources/templates/admin/admin_employer_edit.html
@@ -17,8 +17,10 @@
     <div class="row" style="padding-top: 30px">
         <div class="col-4" id="employerLogo">
             <form id="editLogoForm" class="form-inline">
-                <img id="eLogo" th:src="@{'data:image/png;base64,' + ${photoimg}}" name="logo" alt=""
-                     style="width: 300px;height: 300px;"><br>
+                <img th:if="${photoimg != null}" id="eLogo" th:src="@{'data:image/png;base64,' + ${photoimg}}" name="logo" alt=""
+                     style="width: 300px;height: 300px;">
+                <div th:if="${photoimg == null}" style="width: 300px;height: 300px; background: #808080"></div>
+                <br>
                 <div class="custom-file mt-4">
                     <div class="input-group">
                         <div class="row">
@@ -50,8 +52,9 @@
                 </div>
                 <div class="form-group">
                     <label>Employer last visit : </label><input class="form-control" type="text"
-                                                                th:value="${employerUser.date}" name="date"
+                                                                th:value="${#temporals.format(employerUser.date, 'dd MMMM yyyy HH:mm')}"
                                                                 readonly>
+                    <input class="form-control" type="hidden" th:value="${employerUser.date}" name="date">
                 </div>
                 <div class="form-group">
                     <input class="form-control" type="hidden" th:value="${employerUser.password}"

--- a/src/main/resources/templates/admin/admin_employers.html
+++ b/src/main/resources/templates/admin/admin_employers.html
@@ -59,7 +59,7 @@
                 <tr th:each="employerUser : ${employerUsers}">
                     <td th:text="${employerUser.id}"></td>
                     <td th:text="${employerUser.email}"></td>
-                    <td th:text="${employerUser.date}"></td>
+                    <td th:text="${#temporals.format(employerUser.date, 'dd MMMM yyyy HH:mm')}"></td>
                     <td>
                         <button th:onclick="'editEmployer(\'' + ${employerUser.id} + '\');'" type="button"
                                 class="btn btn-primary">Edit

--- a/src/main/resources/templates/admin/admin_seeker_edit.html
+++ b/src/main/resources/templates/admin/admin_seeker_edit.html
@@ -17,8 +17,10 @@
     <div class="row" style="padding-top: 30px">
         <div class="col-4" id="seekerPhoto">
             <form id="editPhotoForm" class="form-inline">
-                <img id="sPhoto" th:src="@{'data:image/png;base64,' + ${photoimg}}" name="photo" alt=""
-                     style="height: 300px;width: 300px;"><br>
+                <img th:if="${photoimg != null}" id="sPhoto" th:src="@{'data:image/png;base64,' + ${photoimg}}" name="photo" alt=""
+                     style="width: 300px;height: 300px;">
+                <div th:if="${photoimg == null}" style="width: 300px;height: 300px; background: #808080"></div>
+                <br>
                 <div class="custom-file mt-4">
                     <div class="input-group">
                         <div class="row">
@@ -46,12 +48,13 @@
                 </div>
                 <div class="form-group">
                     <label>Seeker email : </label><input class="form-control" type="text"
-                                                         th:value="${seekerUser.email}" name="email">
+                                                         th:value="${seekerUser.email}" name="email" readonly>
                 </div>
                 <div class="form-group">
                     <label>Seeker last visit : </label><input class="form-control" type="text"
-                                                              th:value="${seekerUser.date}" name="date"
-                                                              readonly>
+                                                              th:value="${#temporals.format(seekerUser.date, 'dd MMMM yyyy HH:mm')}"
+                                                                readonly>
+                    <input class="form-control" type="hidden" th:value="${seekerUser.date}" name="date">
                 </div>
                 <div class="form-group">
                     <input class="form-control" type="hidden" th:value="${seekerUser.password}" name="password">

--- a/src/main/resources/templates/admin/admin_seekers.html
+++ b/src/main/resources/templates/admin/admin_seekers.html
@@ -58,7 +58,7 @@
                 <tr th:each="seekerUser : ${seekerUsers}">
                     <td th:text="${seekerUser.id}"></td>
                     <td th:text="${seekerUser.email}"></td>
-                    <td th:text="${seekerUser.date}"></td>
+                    <td th:text="${#temporals.format(seekerUser.date, 'dd MMMM yyyy HH:mm')}"></td>
                     <td>
                         <button th:onclick="'editSeeker(\'' + ${seekerUser.id} + '\');'" type="button"
                                 class="btn btn-primary">Edit


### PR DESCRIPTION
- подключил расширение Thymeleaf для форматирования даты в шаблоне в pom
- добавил форматирование даты на страницах списков и редактирования Seeker/Empolyer
- на странице редактирования поле Email изменил на readonly
- обновил js файлы, добавил параметр type  для Seeker/Empolyer объектов для починки редактирования
- обновил контроллер Admin для поддержки отсутствующего Лого/Фото
- при отсутствии фото - вывожу серый div аналогичного размера.