### PR TITLE
get rid of duplicate links to seekerProfile

### DIFF
--- a/src/main/java/com/jm/jobseekerplatform/JobseekerPlatformApplication.java
+++ b/src/main/java/com/jm/jobseekerplatform/JobseekerPlatformApplication.java
@@ -13,7 +13,7 @@ public class JobseekerPlatformApplication {
     }
 
     //delete "//" to enable init userroles and users to base
-    //@Bean(initMethod = "initData")
+//    @Bean(initMethod = "initData")
     public InitData initialData() {
         return new InitData();
     }

--- a/src/main/java/com/jm/jobseekerplatform/controller/EmployerController.java
+++ b/src/main/java/com/jm/jobseekerplatform/controller/EmployerController.java
@@ -68,7 +68,7 @@ public class EmployerController {
                 if (roles.contains("ROLE_SEEKER")) {
                     boolean isContain = false;
                     SeekerUser seekerUser = seekerUserService.getById(userId);
-                    if (employerProfile.getReviews().stream().anyMatch(reviews1 -> Objects.equals(reviews1.getSeekerProfile().getId(), seekerUser.getProfile().getId()))) {
+                    if (employerProfile.getReviews().stream().anyMatch(reviews1 -> Objects.equals(reviews1.getCreatorProfile().getId(), seekerUser.getProfile().getId()))) {
                         isContain = true;
                     }
                     model.addAttribute("seekerProfileId", seekerUser.getProfile().getId());

--- a/src/main/java/com/jm/jobseekerplatform/controller/rest/ReviewsRestController.java
+++ b/src/main/java/com/jm/jobseekerplatform/controller/rest/ReviewsRestController.java
@@ -79,7 +79,7 @@ public class ReviewsRestController {
         try {
             EmployerProfile employerProfile = employerProfileService.getById(((Number) map.get("employerProfiles_id")).longValue());
             Set<EmployerReviews> reviewsSet = employerProfile.getReviews();
-            EmployerReviews reviews = reviewsSet.stream().filter(employerReviews -> employerReviews.getSeekerProfile().getId() == ((Number) map.get("seekerProfiles_id")).longValue()).findFirst().orElse(null);
+            EmployerReviews reviews = reviewsSet.stream().filter(employerReviews -> employerReviews.getCreatorProfile().getId() == ((Number) map.get("seekerProfiles_id")).longValue()).findFirst().orElse(null);
             if (reviews != null) return new ResponseEntity<>(reviews, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -102,11 +102,11 @@ public class ReviewsRestController {
                                        @RequestParam("seekerProfileId") Long seekerProfileId,
                                        @RequestParam("employerProfileId") Long employerProfileId) {
         EmployerProfile employerProfile = employerProfileService.getById(employerProfileId);
-        if (employerProfile.getReviews().stream().anyMatch(reviews1 -> Objects.equals(reviews1.getSeekerProfile().getId(), seekerProfileId))) {
+        if (employerProfile.getReviews().stream().anyMatch(reviews1 -> Objects.equals(reviews1.getCreatorProfile().getId(), seekerProfileId))) {
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
         }
         SeekerProfile seekerProfile = seekerProfileService.getById(seekerProfileId);
-        reviews.setSeekerProfile(seekerProfile);
+        reviews.setCreatorProfile(seekerProfile);
         reviews.setCreatorProfile(seekerProfile);
         reviews.setHeadline(seekerProfile.getFullName());
         employerReviewsService.add(reviews);
@@ -118,7 +118,7 @@ public class ReviewsRestController {
     @PostMapping("/update")
     public ResponseEntity updateReview(@RequestBody EmployerReviews reviews,
                                        @RequestParam("seekerProfileId") Long seekerProfileId) {
-        reviews.setSeekerProfile(seekerProfileService.getById(seekerProfileId));
+        reviews.setCreatorProfile(seekerProfileService.getById(seekerProfileId));
         reviews.setCreatorProfile(seekerProfileService.getById(seekerProfileId));
         employerReviewsService.update(reviews);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/jm/jobseekerplatform/model/EmployerReviews.java
+++ b/src/main/java/com/jm/jobseekerplatform/model/EmployerReviews.java
@@ -26,10 +26,6 @@ public class EmployerReviews extends CreatedBySeekerProfileBase implements Seria
     @Column(name = "review_dislike")
     private int dislike;
 
-    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.EAGER)
-    @JoinColumn(name = "seekerProfile")
-    private SeekerProfile seekerProfile;
-
     public EmployerReviews() {
     }
 
@@ -38,13 +34,8 @@ public class EmployerReviews extends CreatedBySeekerProfileBase implements Seria
         this.reviews = reviews;
         this.dateReviews = dateReviews;
         this.evaluation = evaluation;
-        this.seekerProfile = seekerProfile;
     }
 
-    @Override
-    public String getHeadline() {
-        return this.seekerProfile.getFullName();
-    }
 
     @Override
     public String getTypeName() {
@@ -107,15 +98,6 @@ public class EmployerReviews extends CreatedBySeekerProfileBase implements Seria
         --this.dislike;
     }
 
-    public SeekerProfile getSeekerProfile() {
-        return seekerProfile;
-    }
-
-    public void setSeekerProfile(SeekerProfile seekerProfile) {
-        this.seekerProfile = seekerProfile;
-    }
-
-
     @Override
     public String toString() {
         return "EmployerReviews{" +
@@ -125,7 +107,6 @@ public class EmployerReviews extends CreatedBySeekerProfileBase implements Seria
                 ", evaluation=" + evaluation +
                 ", like=" + like +
                 ", dislike=" + dislike +
-                ", seekerProfile=" + seekerProfile +
                 '}';
     }
 

--- a/src/main/java/com/jm/jobseekerplatform/model/chats/ChatWithTopicReview.java
+++ b/src/main/java/com/jm/jobseekerplatform/model/chats/ChatWithTopicReview.java
@@ -3,7 +3,6 @@ package com.jm.jobseekerplatform.model.chats;
 import com.jm.jobseekerplatform.model.EmployerReviews;
 import com.jm.jobseekerplatform.model.profiles.Profile;
 import com.jm.jobseekerplatform.model.users.User;
-
 import javax.persistence.Entity;
 import java.util.List;
 

--- a/src/main/java/com/jm/jobseekerplatform/model/createdByProfile/CreatedBySeekerProfileBase.java
+++ b/src/main/java/com/jm/jobseekerplatform/model/createdByProfile/CreatedBySeekerProfileBase.java
@@ -9,6 +9,7 @@ import javax.persistence.InheritanceType;
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class CreatedBySeekerProfileBase extends CreatedByProfileBase<SeekerProfile> {
+
     public CreatedBySeekerProfileBase() {
     }
 


### PR DESCRIPTION
Ссылка на seekerProfile теперь не дублируется в EmployerReviews, осталась только ссылка в родительском классе CreatedByProfileBase.